### PR TITLE
Remove copper check from mask cutout render

### DIFF
--- a/qrcode_footprint_wizard_segno.py
+++ b/qrcode_footprint_wizard_segno.py
@@ -190,7 +190,7 @@ class QRCodeWizardSegno(FootprintWizardBase.FootprintWizard):
             y_position += self.pixel_size
 
         # add mask cutout
-        if self.use_cu and self.mask_cut_out:
+        if self.mask_cut_out:
             self.__add_mask_cutout()
         self.__draw_courtyard()
 


### PR DESCRIPTION
# Description
This removes the check for copper micro qr being enabled when deciding to create a solder mask cutout or not
<!--
  Describe the change that this pull request makes and how it is implemented.
-->

## Checklist

- [x] I have run `pre-commit install` and all `pre-commit` checks passed.
- [x] I have checked open issues and identified any that this PR will close.

## Notes
Closes: #8 
<!--
  Add any extra notes or detail. Link any issues that this PR will close, i.e. closes #10

  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Closes #10
-->
